### PR TITLE
Updates, mainly remove rust-crypto in favor of bitcoin_hashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,6 @@ path = "src/bin/ots_info.rs"
 
 [dependencies]
 bitcoin_hashes = "0.12.0"
-env_logger = "0.4"
-log = "0.3"
+env_logger = "0.10"
+log = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ name = "ots-info"
 path = "src/bin/ots_info.rs"
 
 [dependencies]
+bitcoin_hashes = "0.12.0"
 env_logger = "0.4"
 log = "0.3"
-rust-crypto = "0.2"
 

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -76,9 +76,9 @@ impl Attestation {
             let uri_string = String::from_utf8(uri_bytes)?;
             for ch in uri_string.chars() {
                 match ch {
-                    'a'...'z' => {}
-                    'A'...'Z' => {}
-                    '0'...'9' => {}
+                    'a'..='z' => {}
+                    'A'..='Z' => {}
+                    '0'..='9' => {}
                     '.' | '-' | '_' | '/' | ':' => {},
                     x => return Err(Error::InvalidUriChar(x))
                 }

--- a/src/bin/ots_info.rs
+++ b/src/bin/ots_info.rs
@@ -28,7 +28,7 @@ extern crate opentimestamps as ots;
 use std::{env, fs, process};
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let args: Vec<String> = env::args().collect();
     if args.len() != 2 {

--- a/src/error.rs
+++ b/src/error.rs
@@ -74,22 +74,8 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::StackOverflow => "recursion limit reached",
-            Error::InvalidUriChar(_) => "invalid character in URI",
-            Error::BadDigestTag(_) => "invalid digest tag",
-            Error::BadOpTag(_) => "invalid op tag",
-            Error::BadMagic(_) => "bad magic bytes, is this a timestamp file?",
-            Error::BadVersion(_) => "timestamp version not understood",
-            Error::BadLength { .. } => "length out of bounds",
-            Error::TrailingBytes => "expected eof not",
-            Error::Utf8(ref e) => error::Error::description(e),
-            Error::Io(ref e) => error::Error::description(e)
-        }
-    }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Utf8(ref e) => Some(e),
             Error::Io(ref e) => Some(e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 #![deny(unused_mut)]
 #![deny(missing_docs)]
 
-extern crate crypto;
+extern crate bitcoin_hashes;
 #[macro_use] extern crate log;
 
 pub mod attestation;

--- a/src/op.rs
+++ b/src/op.rs
@@ -18,13 +18,10 @@
 //! timestamps.
 //!
 
-use crypto::digest::Digest;
-use crypto::sha1::Sha1;
-use crypto::sha2::Sha256;
-use crypto::ripemd160::Ripemd160;
 use std::fmt;
 use std::io::{Read, Write};
 
+use bitcoin_hashes::{Hash, ripemd160, sha1, sha256};
 use error::Error;
 use hex::Hexed;
 use ser;
@@ -100,25 +97,13 @@ impl Op {
     pub fn execute(&self, input: &[u8]) -> Vec<u8> {
         match *self {
             Op::Sha1 => {
-                let mut ret = vec![0; 20];
-                let mut hasher = Sha1::new();
-                hasher.input(input);
-                hasher.result(&mut ret);
-                ret
+                sha1::Hash::hash(&input).to_byte_array().to_vec()
             }
             Op::Sha256 => {
-                let mut ret = vec![0; 32];
-                let mut hasher = Sha256::new();
-                hasher.input(input);
-                hasher.result(&mut ret);
-                ret
+                sha256::Hash::hash(&input).to_byte_array().to_vec()
             }
             Op::Ripemd160 => {
-                let mut ret = vec![0; 20];
-                let mut hasher = Ripemd160::new();
-                hasher.input(input);
-                hasher.result(&mut ret);
-                ret
+                ripemd160::Hash::hash(&input).to_byte_array().to_vec()
             }
             Op::Hexlify => {
                 format!("{}", Hexed(input)).into_bytes()

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -295,25 +295,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn digest_type_rt() {
-        macro_rules! check_digest_type {
-            ($($tag: ident),*) => {
-                // Empty match to trigger exhaustiveness checking
-                match DigestType {
-                    $(DigestType::$tag => {}),*
-                }
-                // RTT each in turn
-                $({
-                    let tag = DigestType::$tag.to_tag();
-                    assert!(DigestType::from_tag(tag).is_ok());
-                    let from = DigestType::from_tag(tag).unwrap();
-                    assert_eq!(DigestType::$tag, from);
-                })*
-            }
-        };
-    }
-
-    #[test]
     fn digest_len() {
         assert_eq!(DigestType::Sha1.digest_len(), 20);
         assert_eq!(DigestType::Sha256.digest_len(), 32);


### PR DESCRIPTION
This lib is used by [nostr-ots](https://github.com/RCasatta/nostr-ots) and some errors begin to appear there:

```
warning: the following packages contain code that will be rejected by a future version of Rust: rustc-serialize v0.3.24
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 17`
```

I think we can get rid of rust-crypto since bitcoin_hashes perform the needed hashes and is more likely to be in the tree of a project using rust-opentimestamps.

Other commits are removing warnings, unused code and modernizing a bit